### PR TITLE
fix #18

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -33,7 +33,7 @@ func Home(db *sqlx.DB, ds *DarkmodeStatus) func(c *gin.Context) {
 		for _, iss := range issuesRaw {
 			issues = append(issues,
 				DisplayIssue{
-					fmt.Sprintf("issue/%v/0", iss.ID),
+					fmt.Sprintf("issue/%v", iss.ID),
 					iss.Title,
 					iss.PublishingDate.Format(time.DateOnly),
 					coverpage(iss.Coverpage),
@@ -42,6 +42,73 @@ func Home(db *sqlx.DB, ds *DarkmodeStatus) func(c *gin.Context) {
 		c.HTML(http.StatusOK, "home.html", gin.H{
 			"pagetitle": "dbuggen",
 			"issues":    issues,
+		})
+	}
+}
+
+// Abritrary issue featuring all the articles
+func Issue(db *sqlx.DB, ds *DarkmodeStatus) func(c *gin.Context) {
+	type issueArticle struct {
+		Title       string
+		ArticleLink string
+		Authors     string
+		Content     template.HTML
+		LastEdited  string
+	}
+
+	return func(c *gin.Context) {
+		issueID, err := pathIntSeparator(c.Param("issue"))
+		if err != nil {
+			c.Redirect(http.StatusBadRequest, "")
+			return
+		}
+
+		darkmode := Darkmode(ds)
+
+		issue, err := database.GetIssue(db, issueID, darkmode)
+		if err != nil {
+			c.Redirect(http.StatusInternalServerError, "")
+			return
+		}
+
+		articles, err := database.GetArticles(db, issueID, darkmode)
+		if err != nil {
+			c.Redirect(http.StatusInternalServerError, "")
+			return
+		}
+
+		var issueArticles []issueArticle
+		for _, article := range articles {
+			var authors string
+			if article.AuthorText.Valid {
+				emptyAuthors := make([]database.Author, 0)
+				authors = authortext(article.AuthorText, emptyAuthors)
+			} else {
+				databaseAuthors, err := database.GetAuthors(db, article.ID)
+				if err != nil {
+					c.Redirect(http.StatusInternalServerError, "")
+					return
+				}
+
+				authors = authortext(article.AuthorText, databaseAuthors)
+			}
+
+			content := mdToHTML(article.Content)
+			lastEdited := article.LastEdited.Format(time.DateOnly)
+			issueArticle := issueArticle{
+				Title:       article.Title,
+				ArticleLink: fmt.Sprintf("/issue/%v/%v", issue.ID, article.IssueIndex),
+				Authors:     authors,
+				Content:     content,
+				LastEdited:  lastEdited,
+			}
+			issueArticles = append(issueArticles, issueArticle)
+		}
+
+		c.HTML(http.StatusOK, "issue.html", gin.H{
+			"coverpage":  coverpage(issue.Coverpage),
+			"issueTitle": issue.Title,
+			"articles":   issueArticles,
 		})
 	}
 }

--- a/client/html/issue.html
+++ b/client/html/issue.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<body>
+    {{template "index" .}}
+    <main>
+        {{.coverpage}}
+        <h1>{{.issueTitle}}</h1>
+        <div class="articleContent">
+            {{range .articles}}
+            <hr>
+            
+            <a href={{.ArticleLink}}>
+                <h2>{{.Title}}</h2>
+            </a>
+            <h3>{{.Authors}}</h3>
+            {{.Content}}
+
+            <p>Last edited on {{.LastEdited}}</p>
+            {{end}}
+        </div>
+    </main>
+</body>

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ func Start(db *sqlx.DB, conf *config.Config) {
 	initDarkmode(&ds, conf.DARKMODE_URL)
 
 	r.GET("/", client.Home(db, &ds))
+	r.GET("issue/:issue", client.Issue(db, &ds))
 	r.GET("issue/:issue/:article", client.Article(db, &ds))
 
 	r.NoRoute(func(c *gin.Context) {


### PR DESCRIPTION
Instead of fixing the actual issue this will now give the reader a complete view of the all articles of an issue on the same page, and let them click on each article to get to those individually. There is now no need to be able to change between articles on each article page.